### PR TITLE
New bible versions

### DIFF
--- a/bibleup/bibleup.ts
+++ b/bibleup/bibleup.ts
@@ -34,7 +34,7 @@ export default class BibleUp {
   constructor(element: HTMLElement, options: Partial<Options>) {
     this.#element = element
     this.#defaultOptions = {
-      version: 'ASV',
+      version: 'KJV',
       popup: 'classic',
       darkTheme: false,
       bu_ignore: ['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'A'],

--- a/bibleup/bibleup.ts
+++ b/bibleup/bibleup.ts
@@ -244,7 +244,7 @@ export default class BibleUp {
     trigger: Trigger = { version: true, popup: true, style: true }
   ) {
     if (trigger.version && options.version) {
-      const versions = ['KJV', 'ASV', 'LSV', 'WEB', 'ESV']
+      const versions = Bible.supportedVersions.all
       if (versions.includes(options.version.toUpperCase()) === false) {
         this.#error(
           'The version in BibleUp options is currently not supported. Try with other supported versions'

--- a/bibleup/bibleup.ts
+++ b/bibleup/bibleup.ts
@@ -244,7 +244,7 @@ export default class BibleUp {
     trigger: Trigger = { version: true, popup: true, style: true }
   ) {
     if (trigger.version && options.version) {
-      const versions = ['KJV', 'ASV', 'LSV', 'WEB']
+      const versions = ['KJV', 'ASV', 'LSV', 'WEB', 'ESV']
       if (versions.includes(options.version.toUpperCase()) === false) {
         this.#error(
           'The version in BibleUp options is currently not supported. Try with other supported versions'

--- a/bibleup/bibleup.ts
+++ b/bibleup/bibleup.ts
@@ -320,7 +320,7 @@ export default class BibleUp {
    * @returns Object of Type `Regex` containing main regex and standalone verse regex
    */
   #generateRegex(): Regex {
-    const versions = 'KJV|ASV|LSV|WEB'
+    const versions = Bible.supportedVersions.all.join('|')
     const bookNames = Bible.allAbbreviations()
 
     const main = `(?:(?:(${bookNames.all})(?:\\.?)\\s?(\\d{1,3})(?:\\:\\s?(\\d{1,3}(?:\\s?\\-\\s?\\d{1,3})?))?)(?:[a-zA-Z])?(?:\\s(${versions}))?)(?:\\s?(?:\\,|\\;|\\&)\\s?(?!\\s?(?:${bookNames.multipart})(?:\\.?)\\b)\\s?(?:\\d{1,3}\\s?\\-\\s?\\d{1,3}|\\d{1,3}\\:\\d{1,3}(?:\\-\\d{1,3})?|\\d{1,3})(?:[a-zA-Z](?![a-zA-Z]))?(?:\\s(${versions}))?)*`

--- a/bibleup/bibleup.ts
+++ b/bibleup/bibleup.ts
@@ -45,10 +45,10 @@ export default class BibleUp {
     }
 
     if (typeof options === 'object' && options !== null) {
-      this.#options = this.#DEPRECATE_bu_id({
+      this.#options = {
         ...this.#defaultOptions,
         ...options
-      })
+      }
     } else {
       this.#options = this.#defaultOptions
     }
@@ -82,23 +82,6 @@ export default class BibleUp {
    */
   get #buid(): string {
     return this.#options.buid || this.#initKey
-  }
-
-  /**
-   * The method removes the `bu_id` property and replaces it with `buid` to match documentation.
-   * DEPRECATES `bu_id` and Enforces `buid`
-   * @param {*} options - BibleUp Options
-   * @returns 0bject
-   */
-  #DEPRECATE_bu_id(options: Options): Options {
-    if (
-      Object.prototype.hasOwnProperty.call(options, 'bu_id') &&
-      options.bu_id
-    ) {
-      options.buid = options.bu_id
-      delete options.bu_id
-    }
-    return options
   }
 
   /**
@@ -142,7 +125,7 @@ export default class BibleUp {
     new0ptions: Partial<Options>
   ) {
     if (force === true) {
-      return this.#DEPRECATE_bu_id({ ...defaultOptions, ...new0ptions })
+      return { ...defaultOptions, ...new0ptions }
     } else {
       const merge: Options = { ...this.#options, ...new0ptions }
       for (const [key, value] of Object.entries(new0ptions)) {
@@ -162,7 +145,7 @@ export default class BibleUp {
         }
       }
 
-      return this.#DEPRECATE_bu_id(merge)
+      return merge
     }
   }
 

--- a/bibleup/bibleup.ts
+++ b/bibleup/bibleup.ts
@@ -34,7 +34,7 @@ export default class BibleUp {
   constructor(element: HTMLElement, options: Partial<Options>) {
     this.#element = element
     this.#defaultOptions = {
-      version: 'KJV',
+      version: 'ASV',
       popup: 'classic',
       darkTheme: false,
       bu_ignore: ['H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'A'],
@@ -244,7 +244,7 @@ export default class BibleUp {
     trigger: Trigger = { version: true, popup: true, style: true }
   ) {
     if (trigger.version && options.version) {
-      const versions = Bible.supportedVersions.all
+      const versions = Bible.supportedVersions.all as readonly string[]
       if (versions.includes(options.version.toUpperCase()) === false) {
         this.#error(
           'The version in BibleUp options is currently not supported. Try with other supported versions'

--- a/bibleup/css/bibleup.less
+++ b/bibleup/css/bibleup.less
@@ -11,12 +11,9 @@
   font-weight: var(--bu-font-weight);
   line-height: var(--bu-line-height);
   -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   z-index: 1070; //bootstrap default for popovers
-}
-
-.bu-popup-content ol li {
-  font-size: var(--bu-font-size);
 }
 
 [id^='bu-popup-'] * {

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -32,11 +32,18 @@ export const getBookId = (book: string) => {
   return bible ? bible.id : undefined
 }
 
-/* export const supportedVersions = {
-  bolls: ['ESV'],
+/**
+ * Supported Bible versions
+ * @property bibleApi - Versions to be fetched through api.bible
+ * @property bolls - Versions to be fetched through Bolls
+ */
+export const supportedVersions = {
   bibleApi: ['KJV', 'ASV', 'LSV', 'WEB'],
-  all: [...bolls, ...bibleApi]
-} */
+  bolls: ['ESV'],
+  get all() {
+    return [...this.bolls, ...this.bibleApi]
+  }
+}
 
 /**
  * @returns The abbreviated book name recognised by api.bible

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -23,6 +23,22 @@ export const allAbbreviations = () => {
 }
 
 /**
+ * @returns The book ID for a particular Bible book
+ * - accepts standard book - 'Psalm'
+ * - returns ID - 19
+ */
+export const getBookId = (book: string) => {
+  const bible = bibleData.find((bible) => bible.book === book)
+  return bible ? bible.id : undefined
+}
+
+/* export const supportedVersions = {
+  bolls: ['ESV'],
+  bibleApi: ['KJV', 'ASV', 'LSV', 'WEB'],
+  all: [...bolls, ...bibleApi]
+} */
+
+/**
  * @returns The abbreviated book name recognised by api.bible
  * - accepts standard book - 'Psalm'
  * - returns abbr book for API/URL - 'PSA'

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -41,7 +41,7 @@ export const getBookId = (book: string) => {
  */
 export const supportedVersions: SupportedVersions = {
   bibleApi: ['KJV', 'ASV', 'LSV', 'WEB'],
-  bolls: ['ESV', 'NIV', 'MSG', 'NLT', 'AMP'],
+  bolls: ['ESV', 'NIV', 'MSG', 'NLT', 'AMP', 'NASB'],
   get all() {
     return [...this.bolls, ...this.bibleApi]
   }

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -39,7 +39,7 @@ export const getBookId = (book: string) => {
  */
 export const supportedVersions: SupportedVersions = {
   bibleApi: ['KJV', 'ASV', 'LSV', 'WEB'],
-  bolls: ['ESV'],
+  bolls: ['ESV', 'NIV'],
   get all() {
     return [...this.bolls, ...this.bibleApi]
   }

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -1,5 +1,5 @@
 import bibleData from './bible-data.js'
-import { BibleData, BibleRef } from './interfaces.js'
+import { BibleData, BibleRef, SupportedVersions } from './interfaces.js'
 
 /**
  * @return All book names and abbreviations separated by '|'
@@ -37,7 +37,7 @@ export const getBookId = (book: string) => {
  * @property bibleApi - Versions to be fetched through api.bible
  * @property bolls - Versions to be fetched through Bolls
  */
-export const supportedVersions = {
+export const supportedVersions: SupportedVersions = {
   bibleApi: ['KJV', 'ASV', 'LSV', 'WEB'],
   bolls: ['ESV'],
   get all() {

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -39,7 +39,7 @@ export const getBookId = (book: string) => {
  */
 export const supportedVersions: SupportedVersions = {
   bibleApi: ['KJV', 'ASV', 'LSV', 'WEB'],
-  bolls: ['ESV', 'NIV', 'MSG', 'NLT'],
+  bolls: ['ESV', 'NIV', 'MSG', 'NLT', 'AMP'],
   get all() {
     return [...this.bolls, ...this.bibleApi]
   }

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -33,7 +33,9 @@ export const getBookId = (book: string) => {
 }
 
 /**
- * Supported Bible versions
+ * An object of supported Bible versions.
+ * @description Each property is an array of versions named after the api service
+ * from which the versions are fetched
  * @property bibleApi - Versions to be fetched through api.bible
  * @property bolls - Versions to be fetched through Bolls
  */

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -39,7 +39,7 @@ export const getBookId = (book: string) => {
  */
 export const supportedVersions: SupportedVersions = {
   bibleApi: ['KJV', 'ASV', 'LSV', 'WEB'],
-  bolls: ['ESV', 'NIV', 'MSG'],
+  bolls: ['ESV', 'NIV', 'MSG', 'NLT'],
   get all() {
     return [...this.bolls, ...this.bibleApi]
   }

--- a/bibleup/helper/bible.ts
+++ b/bibleup/helper/bible.ts
@@ -39,7 +39,7 @@ export const getBookId = (book: string) => {
  */
 export const supportedVersions: SupportedVersions = {
   bibleApi: ['KJV', 'ASV', 'LSV', 'WEB'],
-  bolls: ['ESV', 'NIV'],
+  bolls: ['ESV', 'NIV', 'MSG'],
   get all() {
     return [...this.bolls, ...this.bibleApi]
   }

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -1,6 +1,6 @@
 export interface Options {
-  version: string
-  popup: string
+  version: 'KJV' | 'ASV' | 'WEB' | 'LSV' | 'ESV'
+  popup: 'classic' | 'inline' | 'wiki'
   darkTheme: boolean
   bu_ignore: string[]
   bu_allow: string[]
@@ -81,7 +81,7 @@ export interface BibleApiResponse {
   }
 }
 
-export type BollsApiResponse = Array<Array<{ text: string }>>;
+export type BollsApiResponse = Array<Array<{ text: string }>>
 
 /* export interface supportedVersions {
   bolls: string[],

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -82,12 +82,12 @@ export interface BibleApiResponse {
 
 export type BollsApiResponse = Array<Array<{ text: string }>>
 
+type BibleApi = 'KJV' | 'ASV' | 'LSV' | 'WEB'
+type Bolls = 'ESV' | 'NIV' | 'MSG' | 'NLT' | 'AMP' | 'NASB'
+type Version = BibleApi | Bolls
+
 export interface SupportedVersions {
   bibleApi: BibleApi[]
   bolls: Bolls[]
   all: Version[]
 }
-
-type BibleApi = 'KJV' | 'ASV' | 'LSV' | 'WEB'
-type Bolls = 'ESV' | 'NIV' | 'MSG' | 'NLT' | 'AMP'
-type Version = BibleApi | Bolls

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -90,5 +90,5 @@ export interface SupportedVersions {
 }
 
 type BibleApi = 'KJV' | 'ASV' | 'LSV' | 'WEB'
-type Bolls = 'ESV' | 'NIV'
+type Bolls = 'ESV' | 'NIV' | 'MSG'
 type Version = BibleApi | Bolls

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -90,5 +90,5 @@ export interface SupportedVersions {
 }
 
 type BibleApi = 'KJV' | 'ASV' | 'LSV' | 'WEB'
-type Bolls = 'ESV'
+type Bolls = 'ESV' | 'NIV'
 type Version = BibleApi | Bolls

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -90,5 +90,5 @@ export interface SupportedVersions {
 }
 
 type BibleApi = 'KJV' | 'ASV' | 'LSV' | 'WEB'
-type Bolls = 'ESV' | 'NIV' | 'MSG' | 'NLT'
+type Bolls = 'ESV' | 'NIV' | 'MSG' | 'NLT' | 'AMP'
 type Version = BibleApi | Bolls

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -1,5 +1,5 @@
 export interface Options {
-  version: 'KJV' | 'ASV' | 'WEB' | 'LSV' | 'ESV'
+  version: Version
   popup: 'classic' | 'inline' | 'wiki'
   darkTheme: boolean
   bu_ignore: string[]
@@ -83,8 +83,12 @@ export interface BibleApiResponse {
 
 export type BollsApiResponse = Array<Array<{ text: string }>>
 
-/* export interface supportedVersions {
-  bolls: string[],
-  bibleApi: string[]
-  all: string[]
-} */
+export interface SupportedVersions {
+  bibleApi: BibleApi[]
+  bolls: Bolls[]
+  all: Version[]
+}
+
+type BibleApi = 'KJV' | 'ASV' | 'LSV' | 'WEB'
+type Bolls = 'ESV'
+type Version = BibleApi | Bolls

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -90,5 +90,5 @@ export interface SupportedVersions {
 }
 
 type BibleApi = 'KJV' | 'ASV' | 'LSV' | 'WEB'
-type Bolls = 'ESV' | 'NIV' | 'MSG'
+type Bolls = 'ESV' | 'NIV' | 'MSG' | 'NLT'
 type Version = BibleApi | Bolls

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -5,7 +5,6 @@ export interface Options {
   bu_ignore: string[]
   bu_allow: string[]
   buid: string
-  bu_id?: string
   ignoreCase: boolean
   styles: Partial<Styles>
 }

--- a/bibleup/helper/interfaces.ts
+++ b/bibleup/helper/interfaces.ts
@@ -75,8 +75,16 @@ export type Trigger = Partial<{
   style: boolean
 }>
 
-export interface ApiResponse {
+export interface BibleApiResponse {
   data: {
     content: string
   }
 }
+
+export type BollsApiResponse = Array<Array<{ text: string }>>;
+
+/* export interface supportedVersions {
+  bolls: string[],
+  bibleApi: string[]
+  all: string[]
+} */

--- a/bibleup/helper/search.ts
+++ b/bibleup/helper/search.ts
@@ -7,13 +7,9 @@ import { ApiResponse, BibleFetch, BibleRef } from './interfaces.js'
  * - if text returns null, there was problem fetching the Bible text, else text is an array with Bible texts
  */
 export const getScripture = async (bible: BibleRef, version: string) => {
-  let text: string[] | null
   const versionId = getVersionId(version)
-  if (bible.verseEnd) {
-    text = await getPassage(bible.apiBook, versionId)
-  } else {
-    text = await getText(bible.apiBook, versionId)
-  }
+  const isPassage = bible.verseEnd ? true : false
+  const text = await fetchText(isPassage, bible.apiBook, versionId)
 
   const result: BibleFetch = {
     ref: bible.ref,
@@ -53,11 +49,16 @@ const getVersionId = (version: string) => {
   return id
 }
 
-const getText = async (
-  ref: string,
+const fetchText = async (
+  isPassage: boolean,
+  apiBook: string,
   versionId: string
 ): Promise<string[] | null> => {
-  const url = `https://api.scripture.api.bible/v1/bibles/${versionId}/verses/${ref}?content-type=html&include-notes=false&include-titles=false&include-chapter-numbers=false&include-verse-numbers=false&include-verse-spans=false&use-org-id=false`
+  const type = isPassage ? 'passages' : 'verses'
+  const typePayload = isPassage
+    ? 'include-verse-spans=true'
+    : 'include-verse-spans=false'
+  const url = `https://api.scripture.api.bible/v1/bibles/${versionId}/${type}/${apiBook}?content-type=html&include-notes=false&include-titles=false&include-chapter-numbers=false&include-verse-numbers=false&${typePayload}&use-org-id=false`
 
   try {
     const res = await fetch(url, {
@@ -72,35 +73,7 @@ const getText = async (
     }
 
     const content: ApiResponse = (await res.json()) as ApiResponse
-    return processBibleText(content, 'text')
-  } catch (error) {
-    return null
-  }
-}
-
-/**
- * Get range of verses - ACT.1.8-ACT.1.10
- **/
-const getPassage = async (
-  ref: string,
-  versionId: string
-): Promise<string[] | null> => {
-  const url = `https://api.scripture.api.bible/v1/bibles/${versionId}/passages/${ref}?content-type=html&include-notes=false&include-titles=false&include-chapter-numbers=false&include-verse-numbers=false&include-verse-spans=true&use-org-id=false`
-
-  try {
-    const res = await fetch(url, {
-      method: 'GET',
-      headers: {
-        'api-key': apiKey
-      }
-    })
-
-    if (!res.ok) {
-      throw new Error('A problem occured while fetching data')
-    }
-
-    const content: ApiResponse = (await res.json()) as ApiResponse
-    return processBibleText(content, 'passage')
+    return processBibleText(content, type)
   } catch (error) {
     return null
   }
@@ -109,15 +82,16 @@ const getPassage = async (
 /**
  * parses HTML response from the fetch API and extract the verses.
  * - WARNING: The HTML responses are tricky and had to be parsed based on observations from manual testing
- * - returns array e.g ['Jesus be Glorified', 'Forever'] if type is 'passage'
+ * - if type is `verses`, it returns array with single value ['Jesus be Glorified']
+ * - if type is  `passages`, it returns array of values ['Jesus be Glorified', 'Forever']
  */
 const processBibleText = (
   res: ApiResponse,
-  type: 'text' | 'passage'
+  type: 'verses' | 'passages'
 ): string[] => {
   const result: string[] = []
 
-  if (type === 'text') {
+  if (type === 'verses') {
     const parser = new DOMParser()
     const doc = parser.parseFromString(res.data.content, 'text/html')
     const p = doc.querySelectorAll('p')
@@ -126,7 +100,7 @@ const processBibleText = (
     )
   }
 
-  if (type === 'passage') {
+  if (type === 'passages') {
     const parser = new DOMParser()
     const doc = parser.parseFromString(res.data.content, 'text/html')
     const span = doc.getElementsByClassName('verse-span')

--- a/bibleup/helper/search.ts
+++ b/bibleup/helper/search.ts
@@ -29,7 +29,7 @@ export const getScripture = async (bible: BibleRef, version: string) => {
 
 const getVersionId = (version: string) => {
   let id
-  switch (version) {
+  switch (version.toUpperCase()) {
     case 'KJV':
       id = 'de4e12af7f28f599-01'
       break

--- a/bibleup/helper/search.ts
+++ b/bibleup/helper/search.ts
@@ -5,7 +5,7 @@ import {
   BibleFetch,
   BibleRef
 } from './interfaces.js'
-import { getBookId } from './bible.js'
+import * as Bible from './bible.js'
 
 /**
  * get scripture Text from bible reference
@@ -41,7 +41,7 @@ export const getScripture = async (bible: BibleRef, version: string) => {
 
 const getVersionId = (version: string) => {
   let id
-  const BOLLS_VERSION = ['ESV']
+  const BOLLS_VERSION = Bible.supportedVersions.bolls as string[]
 
   if (BOLLS_VERSION.includes(version.toUpperCase())) {
     return version.toUpperCase()
@@ -99,18 +99,18 @@ const fetchBibleApi = async (
 
 const fetchBolls = async (
   isPassage: boolean,
-  Bible: BibleRef,
+  bible: BibleRef,
   versionId: string
 ): Promise<string[] | null> => {
   const url = 'https://bolls.life/get-verses/'
   const verses = []
 
-  if (isPassage && Bible.verseEnd) {
-    for (let i = Bible.verse; i <= Bible.verseEnd; i++) {
+  if (isPassage && bible.verseEnd) {
+    for (let i = bible.verse; i <= bible.verseEnd; i++) {
       verses.push(i)
     }
   } else {
-    verses.push(Bible.verse)
+    verses.push(bible.verse)
   }
 
   try {
@@ -119,8 +119,8 @@ const fetchBolls = async (
       body: JSON.stringify([
         {
           translation: versionId,
-          book: getBookId(Bible.book),
-          chapter: Bible.chapter,
+          book: Bible.getBookId(bible.book),
+          chapter: bible.chapter,
           verses
         }
       ])

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/normalize.css@8.0.1/normalize.min.css">
   <link rel="stylesheet" href="style.css" />
   <title>Vite + TS</title>
 </head>
@@ -26,9 +27,9 @@
         <ul>
           <li>ROMANS 6</li>
           <li>PsALm 119:109b</li>
-          <li>Rev 1:1 ASV</li>
+          <li>Acts 9:39 </li>
           <li>1 John. 4:7 - 8 KJV</li>
-          <i>Acts 9:39</i>
+          <i>Rev 3: 20</i>
         </ul>
       </div>
       <div class="box">
@@ -38,26 +39,26 @@
           <li>Romans 8:34, 3-5, 3-6,5 KJV</li>
           <li>Psalm 119:109b, 105</li>
           <li>2 Thessalonians 2:1, 5, 6</li>
-          <li>Romans. 3:3, 4, 7, 5-8b, 4</li>
+          <li>Rev. 3:19-20, 4, 7, 5-8b</li>
         </ul>
       </div>
       <div class="box">
         <h3>Chapter-Level References</h3>
         <ul>
-          <li>John 3, 5, 6:2</li>
+          <li>John 3, 5, 6:2-5</li>
           <li>Romans 8:34, 3:5, 6-8</li>
           <li>Psalm 119:109b, 1:1-3</li>
-          <li>2 Thessalonians 2:1, 5, 1:4-5, 6</li>
-          <li>Romans. 3:3, 4, 4:5, 7, 10:9-10, 5-8b, 4</li>
+          <li>2 Thessalonians 2:1-3, 1:4-5</li>
+          <li>Revelation 3, 10:9-10</li>
         </ul>
       </div>
       <div class="box">
         <h3>Version Tagging</h3>
         <ul>
-          <li>Romans 8:34 ASV</li>
-          <li>Psalm 119:109b LSV, 105</li>
-          <li>2 Thessalonians 2:1, 5 LSV, 1:4-5</li>
-          <li>John 3:16 KJV; 5 ASV; 25-26 WEB, 34 KJV</li>
+          <li>John 3 KJV, 5, 6:2-5 WEB</li>
+          <li>Romans 8:34, 3:5 ESV, 6-8</li>
+          <li>Psalm 119:109b ESV, 1:1-3</li>
+          <li>2 Thessalonians 2:1-3, 1:4-5 KJV</li>
         </ul>
       </div>
       <div class="box">
@@ -65,7 +66,6 @@
         <ul>
           <li>Ro 8:34-30</li>
           <li>Ps. 119:109b LSV & 105-90</li>
-          <li>2Thess 2:1; 5; 12</li>
           <li>Jhn 3:16 KJV; 5 & 25-26, 34</li>
           <li>Lev. 10:5-70, 5-7 (ignore invalid references)</li>
         </ul>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,6 +1,6 @@
 console.log('BibleUp Demo')
-//import BibleUp from '@bibleup/bibleup';
-import BibleUp from '../bibleup/bibleup.ts'
+import BibleUp from '@bibleup/bibleup';
+//import BibleUp from '../bibleup/bibleup.ts'
 
 const body = document.querySelector('body') as HTMLElement
 const addBtn = document.querySelector('#add') as HTMLElement
@@ -8,10 +8,11 @@ const removeBtn = document.querySelector('#remove') as HTMLElement
 const refreshBtn = document.querySelector('#refresh') as HTMLElement
 
 const page = new BibleUp(body, {
-  version: 'NIV',
+  version: 'NASB',
   popup: 'classic',
   darkTheme: false,
   //bu_ignore: ['I'],
+  //ignoreCase: true,
   styles: {
     primary: 'linear-gradient(315deg, #f9d976 0%, #f39f86 74%)',
     secondary: 'linear-gradient(315deg, #f9d976 0%, #f39f86 74%)',
@@ -19,7 +20,7 @@ const page = new BibleUp(body, {
     headerColor: '#fff',
     boxShadow: '0 0 0 1px #d0d7de, 0 8px 24px rgba(140,149,159,0.2)',
     fontSize: ''
-  }
+  },
 })
 
 page.create()
@@ -31,7 +32,7 @@ removeBtn.onclick = () => {
 refreshBtn.onclick = () => {
   //page.refresh({popup: 'classic', bu_ignore: ['BLOCKQUOTE'], buid: 'custom1'}, true)
   page.refresh({
-    version: 'kjv',
+    version: 'KJV',
     popup: 'wiki',
     darkTheme: true,
     styles: {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -8,7 +8,7 @@ const removeBtn = document.querySelector('#remove') as HTMLElement
 const refreshBtn = document.querySelector('#refresh') as HTMLElement
 
 const bibleup = new BibleUp(body, {
-  version: 'kjv',
+  version: 'esv',
   popup: 'classic',
   darkTheme: false,
   //bu_ignore: ['I'],

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -29,12 +29,20 @@ removeBtn.onclick = () => {
 }
 
 refreshBtn.onclick = () => {
-  page.refresh({popup: 'classic', bu_ignore: ['BLOCKQUOTE'], bu_id: 'custom1'}, true)
-  /* page.refresh({
+  //page.refresh({popup: 'classic', bu_ignore: ['BLOCKQUOTE'], buid: 'custom1'}, true)
+  page.refresh({
     version: 'kjv',
     popup: 'wiki',
     darkTheme: true,
-  }, true) */
+    styles: {
+      primary: 'linear-gradient(315deg, #f9d976 0%, #f39f86 74%)',
+      secondary: 'linear-gradient(315deg, #f9d976 0%, #f39f86 74%)',
+      tertiary: '#f2f2f2',
+      headerColor: '#fff',
+      boxShadow: '0 0 0 1px #d0d7de, 0 8px 24px rgba(140,149,159,0.2)',
+      fontSize: '12px'
+    }
+  }, true)
 }
 
 addBtn.onclick = () => {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -8,7 +8,7 @@ const removeBtn = document.querySelector('#remove') as HTMLElement
 const refreshBtn = document.querySelector('#refresh') as HTMLElement
 
 const bibleup = new BibleUp(body, {
-  version: 'ESV',
+  version: 'NIV',
   popup: 'classic',
   darkTheme: false,
   //bu_ignore: ['I'],

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,6 +1,6 @@
 console.log('BibleUp Demo')
-//import BibleUp from '@bibleup/bibleup';
-import BibleUp from '../bibleup/bibleup.ts'
+import BibleUp from '@bibleup/bibleup';
+//import BibleUp from '../bibleup/bibleup.ts'
 
 const body = document.querySelector('body') as HTMLElement
 const addBtn = document.querySelector('#add') as HTMLElement
@@ -8,7 +8,7 @@ const removeBtn = document.querySelector('#remove') as HTMLElement
 const refreshBtn = document.querySelector('#refresh') as HTMLElement
 
 const bibleup = new BibleUp(body, {
-  version: 'esv',
+  version: 'ASV',
   popup: 'classic',
   darkTheme: false,
   //bu_ignore: ['I'],

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -8,7 +8,7 @@ const removeBtn = document.querySelector('#remove') as HTMLElement
 const refreshBtn = document.querySelector('#refresh') as HTMLElement
 
 const bibleup = new BibleUp(body, {
-  version: 'ASV',
+  version: 'ESV',
   popup: 'classic',
   darkTheme: false,
   //bu_ignore: ['I'],

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -7,7 +7,7 @@ const addBtn = document.querySelector('#add') as HTMLElement
 const removeBtn = document.querySelector('#remove') as HTMLElement
 const refreshBtn = document.querySelector('#refresh') as HTMLElement
 
-const bibleup = new BibleUp(body, {
+const page = new BibleUp(body, {
   version: 'NIV',
   popup: 'classic',
   darkTheme: false,
@@ -22,21 +22,15 @@ const bibleup = new BibleUp(body, {
   }
 })
 
-/* const bibleupp = new BibleUp(body, {
-  version: 'kjv',
-  popup: 'classic',
-  darkTheme: false
-}) */
-
-bibleup.create()
+page.create()
 
 removeBtn.onclick = () => {
-  bibleup.destroy(false)
+  page.destroy(false)
 }
 
 refreshBtn.onclick = () => {
-  bibleup.refresh({popup: 'classic', bu_ignore: ['BLOCKQUOTE'], bu_id: 'custom1'}, true)
-  /* bibleup.refresh({
+  page.refresh({popup: 'classic', bu_ignore: ['BLOCKQUOTE'], bu_id: 'custom1'}, true)
+  /* page.refresh({
     version: 'kjv',
     popup: 'wiki',
     darkTheme: true,

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,6 +1,6 @@
 console.log('BibleUp Demo')
-import BibleUp from '@bibleup/bibleup';
-//import BibleUp from '../bibleup/bibleup.ts'
+//import BibleUp from '@bibleup/bibleup';
+import BibleUp from '../bibleup/bibleup.ts'
 
 const body = document.querySelector('body') as HTMLElement
 const addBtn = document.querySelector('#add') as HTMLElement

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,17 +1,20 @@
 @import '@bibleup/bibleup/css';
 
 html {
+  width: 100%;
   margin: 0;
   padding: 0;
 }
 
 body {
+  width: 100%;
   height: 100%;
   font-family: 'Source Sans Pro', sans-serif;
   color: #2d2f3d;
 }
 
 #container {
+  width: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -65,7 +68,7 @@ button {
 }
 
 #test {
-  width: 100%;
+  width: 80%;
   max-width: 500px;
   height: 300px;
   margin: 40px auto;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,25 +1,21 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
     devDependencies:
       '@babel/plugin-transform-runtime':
         specifier: ^7.21.4
-        version: 7.21.4(@babel/core@7.21.4)
+        version: 7.21.4(@babel/core@7.23.0)
       '@babel/preset-env':
         specifier: ^7.21.4
-        version: 7.21.4(@babel/core@7.21.4)
+        version: 7.21.4(@babel/core@7.23.0)
       '@release-it/conventional-changelog':
         specifier: ^5.1.1
         version: 5.1.1(release-it@15.11.0)
       '@rollup/plugin-babel':
         specifier: ^5.3.1
-        version: 5.3.1(@babel/core@7.21.4)(rollup@2.79.1)
+        version: 5.3.1(@babel/core@7.23.0)(rollup@2.79.1)
       '@rollup/plugin-commonjs':
         specifier: ^22.0.2
         version: 22.0.2(rollup@2.79.1)
@@ -116,14 +112,15 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.19
     dev: true
 
-  /@babel/code-frame@7.21.4:
-    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
+  /@babel/code-frame@7.22.13:
+    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.22.20
+      chalk: 2.4.2
     dev: true
 
   /@babel/compat-data@7.21.4:
@@ -131,25 +128,30 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core@7.21.4:
-    resolution: {integrity: sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==}
+  /@babel/compat-data@7.22.20:
+    resolution: {integrity: sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/core@7.23.0:
+    resolution: {integrity: sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.4
-      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
-      '@babel/helper-module-transforms': 7.21.2
-      '@babel/helpers': 7.21.0
-      '@babel/parser': 7.21.4
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
-      convert-source-map: 1.9.0
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.23.0
+      '@babel/helper-compilation-targets': 7.22.15
+      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.0)
+      '@babel/helpers': 7.23.1
+      '@babel/parser': 7.23.0
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
+      convert-source-map: 2.0.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -161,6 +163,16 @@ packages:
       '@babel/types': 7.21.4
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator@7.23.0:
+    resolution: {integrity: sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
     dev: true
 
@@ -179,27 +191,38 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
-  /@babel/helper-compilation-targets@7.21.4(@babel/core@7.21.4):
+  /@babel/helper-compilation-targets@7.21.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/compat-data': 7.21.4
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.5
       lru-cache: 5.1.1
       semver: 6.3.0
     dev: true
 
-  /@babel/helper-create-class-features-plugin@7.21.4(@babel/core@7.21.4):
+  /@babel/helper-compilation-targets@7.22.15:
+    resolution: {integrity: sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/compat-data': 7.22.20
+      '@babel/helper-validator-option': 7.22.15
+      browserslist: 4.22.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: true
+
+  /@babel/helper-create-class-features-plugin@7.21.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.21.0
@@ -212,24 +235,24 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helper-create-regexp-features-plugin@7.21.4(@babel/core@7.21.4):
+  /@babel/helper-create-regexp-features-plugin@7.21.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-M00OuhU+0GyZ5iBBN9czjugzWrEq2vDpf/zCYHxxf93ul/Q5rv+a5h+/+0WnI1AebHNVtl5bFV0qsJoH23DbfA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.18.6
       regexpu-core: 5.3.2
     dev: true
 
-  /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.21.4):
+  /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
     peerDependencies:
       '@babel/core': ^7.4.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.4
       lodash.debounce: 4.0.8
@@ -241,6 +264,11 @@ packages:
 
   /@babel/helper-environment-visitor@7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-environment-visitor@7.22.20:
+    resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -259,11 +287,26 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
+  /@babel/helper-function-name@7.23.0:
+    resolution: {integrity: sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.15
+      '@babel/types': 7.23.0
+    dev: true
+
   /@babel/helper-hoist-variables@7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.21.4
+    dev: true
+
+  /@babel/helper-hoist-variables@7.22.5:
+    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-member-expression-to-functions@7.21.0:
@@ -280,6 +323,13 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
+  /@babel/helper-module-imports@7.22.15:
+    resolution: {integrity: sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: true
+
   /@babel/helper-module-transforms@7.21.2:
     resolution: {integrity: sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==}
     engines: {node: '>=6.9.0'}
@@ -288,12 +338,26 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-simple-access': 7.20.2
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.20
       '@babel/template': 7.20.7
       '@babel/traverse': 7.21.4
       '@babel/types': 7.21.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/helper-module-transforms@7.23.0(@babel/core@7.23.0):
+    resolution: {integrity: sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.23.0
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.20
     dev: true
 
   /@babel/helper-optimise-call-expression@7.18.6:
@@ -308,13 +372,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.21.4):
+  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.23.0):
     resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.20.5
@@ -344,6 +408,13 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
+  /@babel/helper-simple-access@7.22.5:
+    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: true
+
   /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
     resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
@@ -358,8 +429,20 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
+  /@babel/helper-split-export-declaration@7.22.6:
+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: true
+
   /@babel/helper-string-parser@7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-string-parser@7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -368,8 +451,18 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /@babel/helper-validator-identifier@7.22.20:
+    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-option@7.21.0:
     resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-option@7.22.15:
+    resolution: {integrity: sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -385,22 +478,22 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/helpers@7.21.0:
-    resolution: {integrity: sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==}
+  /@babel/helpers@7.23.1:
+    resolution: {integrity: sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.0
+      '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/highlight@7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+  /@babel/highlight@7.22.20:
+    resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
@@ -413,404 +506,412 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.21.4):
+  /@babel/parser@7.23.0:
+    resolution: {integrity: sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: true
+
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.21.4):
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.21.4)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.21.4):
+  /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.4)
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.23.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-class-static-block@7.21.0(@babel/core@7.21.4):
+  /@babel/plugin-proposal-class-static-block@7.21.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.21.4)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.4)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.21.4):
+  /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.23.0):
     resolution: {integrity: sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.21.4)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.4)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.21.4):
+  /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.21.4)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.4)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.4)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.4):
+  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.21.4
-      '@babel/core': 7.21.4
-      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.4)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.4)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.21.4):
+  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.4)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
     dev: true
 
-  /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.0(@babel/core@7.21.4):
+  /@babel/plugin-proposal-private-property-in-object@7.21.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.21.4)
+      '@babel/helper-create-class-features-plugin': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.21.4)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
     engines: {node: '>=4'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-regexp-features-plugin': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.21.4):
+  /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.4):
+  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.0):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.21.4):
+  /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.21.4):
+  /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.21.4):
+  /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.21.4):
+  /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.21.4):
+  /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.21.4):
+  /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.21.4):
+  /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.21.4):
+  /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.4):
+  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.4):
+  /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.4):
+  /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.21.4):
+  /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.21.4):
+  /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.21.4):
+  /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.21.4):
+  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.21.4)
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.21.4):
+  /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-classes@7.21.0(@babel/core@7.21.4):
+  /@babel/plugin-transform-classes@7.21.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
+      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
@@ -822,121 +923,121 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.21.4):
+  /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/template': 7.20.7
     dev: true
 
-  /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.21.4):
+  /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-regexp-features-plugin': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.21.4):
+  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.23.0):
     resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-for-of@7.21.0(@babel/core@7.21.4):
+  /@babel/plugin-transform-for-of@7.21.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.21.4):
+  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.23.0):
     resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.21.4):
+  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.23.0):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.21.4):
+  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.23.0):
     resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-commonjs@7.21.2(@babel/core@7.21.4):
+  /@babel/plugin-transform-modules-commonjs@7.21.2(@babel/core@7.23.0):
     resolution: {integrity: sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-simple-access': 7.20.2
@@ -944,13 +1045,13 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.21.4):
+  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.23.0):
     resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helper-plugin-utils': 7.20.2
@@ -959,278 +1060,278 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-module-transforms': 7.21.2
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.21.4):
+  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-regexp-features-plugin': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.21.4):
+  /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.21.4):
+  /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.1
     dev: true
 
-  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-runtime@7.21.4(@babel/core@7.21.4):
+  /@babel/plugin-transform-runtime@7.21.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-1J4dhrw1h1PqnNNpzwxQ2UBymJUF8KuPjAAnlLwZcGhHAIqUigFW7cdK6GHoB64ubY4qXQNYknoUeks4Wz7CUA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.4)
-      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.4)
-      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.4)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.23.0)
+      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.23.0)
+      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.23.0)
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.21.4):
+  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.23.0):
     resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: true
 
-  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.21.4):
+  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.23.0):
     resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.21.4):
+  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.23.0):
     resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.21.4):
+  /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.23.0):
     resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.23.0):
     resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-regexp-features-plugin': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-create-regexp-features-plugin': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/preset-env@7.21.4(@babel/core@7.21.4):
+  /@babel/preset-env@7.21.4(@babel/core@7.23.0):
     resolution: {integrity: sha512-2W57zHs2yDLm6GD5ZpvNn71lZ0B/iypSdIeq25OurDKji6AdzV07qp4s3n1/x5BqtiGaTrPN3nerlSCaC5qNTw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.21.4
-      '@babel/core': 7.21.4
-      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-compilation-targets': 7.21.4(@babel/core@7.23.0)
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-option': 7.21.0
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-class-static-block': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.21.4)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.21.4)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.21.4)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.21.4)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.21.4)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.21.4)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.21.4)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.21.4)
-      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.21.4)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-for-of': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.21.4)
-      '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.21.4)
-      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.21.4)
-      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.21.4)
-      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.4)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.21.4)
-      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.21.4)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.21.4)
-      '@babel/preset-modules': 0.1.5(@babel/core@7.21.4)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.23.0)
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.23.0)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-proposal-class-static-block': 7.21.0(@babel/core@7.23.0)
+      '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.23.0)
+      '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.23.0)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.23.0)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.23.0)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0(@babel/core@7.23.0)
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.23.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.23.0)
+      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.23.0)
+      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.23.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.23.0)
+      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.23.0)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.23.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-for-of': 7.21.0(@babel/core@7.23.0)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.23.0)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.23.0)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.23.0)
+      '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.23.0)
+      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.23.0)
+      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.23.0)
+      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.23.0)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.23.0)
+      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.23.0)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.23.0)
+      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.23.0)
+      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.23.0)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.23.0)
+      '@babel/preset-modules': 0.1.5(@babel/core@7.23.0)
       '@babel/types': 7.21.4
-      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.21.4)
-      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.21.4)
-      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.21.4)
+      babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.23.0)
+      babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.23.0)
+      babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.23.0)
       core-js-compat: 3.30.0
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@babel/preset-modules@0.1.5(@babel/core@7.21.4):
+  /@babel/preset-modules@0.1.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.21.4)
+      '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.23.0)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.23.0)
       '@babel/types': 7.21.4
       esutils: 2.0.3
     dev: true
@@ -1250,16 +1351,25 @@ packages:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.22.13
       '@babel/parser': 7.21.4
       '@babel/types': 7.21.4
+    dev: true
+
+  /@babel/template@7.22.15:
+    resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/traverse@7.21.4:
     resolution: {integrity: sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.22.13
       '@babel/generator': 7.21.4
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.21.0
@@ -1273,12 +1383,39 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse@7.23.0:
+    resolution: {integrity: sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.23.0
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types@7.21.4:
     resolution: {integrity: sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
       '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@babel/types@7.23.0:
+    resolution: {integrity: sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
     dev: true
 
@@ -1560,6 +1697,11 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: true
 
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
@@ -1585,6 +1727,13 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.19:
+    resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /@nodelib/fs.scandir@2.1.5:
@@ -1766,7 +1915,7 @@ packages:
       semver: 7.3.8
     dev: true
 
-  /@rollup/plugin-babel@5.3.1(@babel/core@7.21.4)(rollup@2.79.1):
+  /@rollup/plugin-babel@5.3.1(@babel/core@7.23.0)(rollup@2.79.1):
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -1777,7 +1926,7 @@ packages:
       '@types/babel__core':
         optional: true
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.23.0
       '@babel/helper-module-imports': 7.21.4
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       rollup: 2.79.1
@@ -2261,38 +2410,38 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.21.4):
+  /babel-plugin-polyfill-corejs2@0.3.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/compat-data': 7.21.4
-      '@babel/core': 7.21.4
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.23.0)
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.21.4):
+  /babel-plugin-polyfill-corejs3@0.6.0(@babel/core@7.23.0):
     resolution: {integrity: sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.23.0)
       core-js-compat: 3.30.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.21.4):
+  /babel-plugin-polyfill-regenerator@0.4.1(@babel/core@7.23.0):
     resolution: {integrity: sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.4)
+      '@babel/core': 7.23.0
+      '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2394,6 +2543,17 @@ packages:
       update-browserslist-db: 1.0.10(browserslist@4.21.5)
     dev: true
 
+  /browserslist@4.22.1:
+    resolution: {integrity: sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001546
+      electron-to-chromium: 1.4.543
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.13(browserslist@4.22.1)
+    dev: true
+
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
@@ -2481,6 +2641,10 @@ packages:
 
   /caniuse-lite@1.0.30001476:
     resolution: {integrity: sha512-JmpktFppVSvyUN4gsLS0bShY2L9ZUslHLE72vgemBkS43JD2fOvKTKs+GtRwuxrtRGnwJFW0ye7kWRRlLJS9vQ==}
+    dev: true
+
+  /caniuse-lite@1.0.30001546:
+    resolution: {integrity: sha512-zvtSJwuQFpewSyRrI3AsftF6rM0X80mZkChIt1spBGEvRglCrjTniXvinc8JKRoqTwXAgvqTImaN9igfSMtUBw==}
     dev: true
 
   /chalk@2.4.2:
@@ -2794,8 +2958,8 @@ packages:
       q: 1.5.1
     dev: true
 
-  /convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+  /convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
 
   /copy-anything@2.0.6:
@@ -3038,6 +3202,10 @@ packages:
 
   /electron-to-chromium@1.4.356:
     resolution: {integrity: sha512-nEftV1dRX3omlxAj42FwqRZT0i4xd2dIg39sog/CnCJeCcL1TRd2Uh0i9Oebgv8Ou0vzTPw++xc+Z20jzS2B6A==}
+    dev: true
+
+  /electron-to-chromium@1.4.543:
+    resolution: {integrity: sha512-t2ZP4AcGE0iKCCQCBx/K2426crYdxD3YU6l0uK2EO3FZH0pbC4pFz/sZm2ruZsND6hQBTcDWWlo/MLpiOdif5g==}
     dev: true
 
   /emoji-regex@8.0.0:
@@ -3694,8 +3862,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -5004,6 +5172,10 @@ packages:
     resolution: {integrity: sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==}
     dev: true
 
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+    dev: true
+
   /normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
@@ -5289,7 +5461,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.22.13
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -5781,7 +5953,7 @@ packages:
       rollup: 2.79.1
       typescript: 4.9.5
     optionalDependencies:
-      '@babel/code-frame': 7.21.4
+      '@babel/code-frame': 7.22.13
     dev: true
 
   /rollup-plugin-less@1.1.3:
@@ -5841,7 +6013,7 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /rollup@3.21.0:
@@ -5849,7 +6021,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-applescript@5.0.0:
@@ -5910,6 +6082,11 @@ packages:
 
   /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+    hasBin: true
+    dev: true
+
+  /semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
     dev: true
 
@@ -6490,6 +6667,17 @@ packages:
       picocolors: 1.0.0
     dev: true
 
+  /update-browserslist-db@1.0.13(browserslist@4.22.1):
+    resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.22.1
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
   /update-notifier@6.0.2:
     resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
     engines: {node: '>=14.16'}
@@ -6561,7 +6749,7 @@ packages:
       postcss: 8.4.23
       rollup: 3.21.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vm2@3.9.19:
@@ -6742,3 +6930,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Checklist
Bible versions to be added
To close #46  
- [x] English Standard Version, ESV
- [x] Amplified Bible, AMP
- [x] New Living Translation, NLT
- [x] New International Version, NIV
- [x] The Message, MSG
- [x] The New American Standard Bible, NASB

Other Features
- [x] Export literal types for BibleUp options
- [x] Remove `bu_id` from the codebase. `buid` is the only supported property

Documentation
- [ ] Add disclaimer on copyright
- [ ] Update supported versions in Docs